### PR TITLE
Expose lightning sensor RFI detection as a binary sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Example yaml to use in esphome device config:
               name: "Battery Level Atlas"
           - device: 0x00f6
             battery_level:
-              name: "AcuRite 06045M Battery Low"
+              name: "Battery Level AcuRite 06045M"
             rfi:
-              name: "AcuRite 06045M RF Interference"
+              name: "RF Interference AcuRite 06045M"
 
 
     sensor:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Example yaml to use in esphome device config:
           - device: 0x0083
             battery_level:
               name: "Battery Level Atlas"
+          - device: 0x00f6
+            battery_level:
+              name: "AcuRite 06045M Battery Low"
+            rfi:
+              name: "AcuRite 06045M RF Interference"
+
 
     sensor:
       - platform: acurite

--- a/components/acurite/acurite.cpp
+++ b/components/acurite/acurite.cpp
@@ -115,6 +115,7 @@ void AcuRiteComponent::decode_lightning_(uint8_t *data, uint8_t len) {
     for (auto *device : this->devices_) {
       if (device->get_id() == id) {
         device->update_battery(battery);
+        device->update_rfi(rfi);
         device->update_temperature(temp);
         device->update_humidity(humidity);
         device->update_lightning(count);

--- a/components/acurite/acurite.h
+++ b/components/acurite/acurite.h
@@ -8,6 +8,7 @@ namespace acurite {
 class AcuRiteDevice {
  public:
   virtual void update_battery(uint8_t value) {}
+  virtual void update_rfi(bool value) {}
   virtual void update_speed(float value) {}
   virtual void update_direction(float value) {}
   virtual void update_temperature(float value) {}

--- a/components/acurite/binary_sensor/__init__.py
+++ b/components/acurite/binary_sensor/__init__.py
@@ -1,7 +1,13 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_BATTERY_LEVEL, CONF_DEVICE, CONF_ID, DEVICE_CLASS_BATTERY
+from esphome.const import (
+    CONF_BATTERY_LEVEL,
+    CONF_DEVICE,
+    CONF_ID,
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_PROBLEM,
+)
 
 from .. import AcuRiteComponent, acurite_ns
 
@@ -9,17 +15,24 @@ DEPENDENCIES = ["acurite"]
 
 CONF_ACURITE_ID = "acurite_id"
 CONF_DEVICES = "devices"
+CONF_RFI = "rfi"
 
 AcuRiteBinarySensor = acurite_ns.class_("AcuRiteBinarySensor", cg.Component)
 
-DEVICE_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(AcuRiteBinarySensor),
-        cv.Required(CONF_DEVICE): cv.hex_int_range(max=0x3FFF),
-        cv.Required(CONF_BATTERY_LEVEL): binary_sensor.binary_sensor_schema(
-            device_class=DEVICE_CLASS_BATTERY,
-        ),
-    }
+DEVICE_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(AcuRiteBinarySensor),
+            cv.Required(CONF_DEVICE): cv.hex_int_range(max=0x3FFF),
+            cv.Optional(CONF_BATTERY_LEVEL): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_BATTERY,
+            ),
+            cv.Optional(CONF_RFI): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
+        }
+    ),
+    cv.has_at_least_one_key(CONF_BATTERY_LEVEL, CONF_RFI),
 )
 
 CONFIG_SCHEMA = cv.Schema(
@@ -42,4 +55,7 @@ async def to_code(config):
                     device_cfg[CONF_BATTERY_LEVEL]
                 )
                 cg.add(var.set_battery_level_binary_sensor(sens))
+            if CONF_RFI in device_cfg:
+                sens = await binary_sensor.new_binary_sensor(device_cfg[CONF_RFI])
+                cg.add(var.set_rfi_binary_sensor(sens))
             cg.add(parent.add_device(var, device_cfg[CONF_DEVICE]))

--- a/components/acurite/binary_sensor/acurite_binary_sensor.cpp
+++ b/components/acurite/binary_sensor/acurite_binary_sensor.cpp
@@ -12,9 +12,16 @@ void AcuRiteBinarySensor::update_battery(uint8_t value) {
   }
 }
 
+void AcuRiteBinarySensor::update_rfi(bool value) {
+  if (this->rfi_binary_sensor_) {
+    this->rfi_binary_sensor_->publish_state(value);
+  }
+}
+
 void AcuRiteBinarySensor::dump_config() {
   ESP_LOGCONFIG(TAG, "AcuRite Binary Sensor: 0x%04x", this->id_);
   LOG_BINARY_SENSOR("  ", "Battery", this->battery_level_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "RFI", this->rfi_binary_sensor_);
 }
 
 }  // namespace acurite

--- a/components/acurite/binary_sensor/acurite_binary_sensor.h
+++ b/components/acurite/binary_sensor/acurite_binary_sensor.h
@@ -9,9 +9,11 @@ namespace acurite {
 class AcuRiteBinarySensor : public Component, public AcuRiteDevice {
  public:
   void update_battery(uint8_t value) override;
+  void update_rfi(bool value) override;
   void dump_config() override;
 
   SUB_BINARY_SENSOR(battery_level)
+  SUB_BINARY_SENSOR(rfi)
 };
 
 }  // namespace acurite


### PR DESCRIPTION
## What changed

- Exposes the AcuRite lightning detector RFI flag as an optional ESPHome binary sensor.
- Publishes the decoded RFI bit directly, with `ON` indicating detected interference.
- Uses the Home Assistant `problem` device class for the RFI entity.
- Makes `battery_level` optional and requires each AcuRite binary-sensor device entry to configure at least one of `battery_level` or `rfi`.
- Updated readme documentation to show example rfi binary sensor.

## Why

When testing with my AcuRite 06045M sensor, the lightning decoder already extracted and logged the RFI bit, but did not forward it to an ESPHome entity. 
Requiring `battery_level` also prevented an RFI-only binary-sensor configuration, now binary_sensor must have at least one sensor, but it doesn't need to be the low battery sensor.

## Example

```yaml
binary_sensor:
  - platform: acurite
    devices:
      - device: 0x00f6
        rfi:
          name: "Lightning Detector RFI"
```

## Validation

- Tested the component from my repository in ESPHome running on a LilyGo T3 LoRa32 V1.6.1 SX1278 (433Mhz) dev board with an AcuRite 06045M sensor.